### PR TITLE
Migrate to vertx-sql-client

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src"]
- :deps    {org.postgresql/postgresql         {:mvn/version "42.2.6"}
-           io.reactiverse/reactive-pg-client {:mvn/version "0.11.4"}}
+ :deps    {org.postgresql/postgresql {:mvn/version "42.2.6"}
+           io.vertx/vertx-pg-client  {:mvn/version "4.2.1"}}
  :aliases {:test   {:extra-paths ["test"]
-                    :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.1"}
+                    :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}
                                   com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.4.0"}
                                   funcool/promesa                          {:mvn/version "2.0.1"}
                                   manifold                                 {:mvn/version "0.1.8"}

--- a/project.clj
+++ b/project.clj
@@ -9,9 +9,9 @@
   :scm {:name "git"
         :url "https://github.com/metosin/porsas"}
   :dependencies [[org.postgresql/postgresql "42.2.6"]
-                 [io.reactiverse/reactive-pg-client "0.11.4"]]
+                 [io.vertx/vertx-pg-client  "4.2.1"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
-                   :dependencies [[org.clojure/clojure "1.10.1"]
+                   :dependencies [[org.clojure/clojure "1.10.3"]
                                   [com.clojure-goes-fast/clj-async-profiler "0.4.0"]
                                   [funcool/promesa "2.0.1"]
                                   [manifold "0.1.8"]


### PR DESCRIPTION
[reactive-pg-client](https://github.com/vietj/reactive-pg-client/) has been superseded by [vertx-sql-client](https://github.com/eclipse-vertx/vertx-sql-client) and [isn't being maintained](https://github.com/vietj/reactive-pg-client/commit/5250ef2a67f3d9c45ccdd37d93ca50f378218f18) anymore so moving the library to use `vertx-sql-client`.