### PR TITLE
Update deps + sync next.jdbc's RowBuilder

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,16 @@
 {:paths   ["src"]
- :deps    {org.postgresql/postgresql         {:mvn/version "42.2.6"}
+ :deps    {org.postgresql/postgresql         {:mvn/version "42.3.1"}
            io.reactiverse/reactive-pg-client {:mvn/version "0.11.4"}}
  :aliases {:test   {:extra-paths ["test"]
-                    :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.1"}
-                                  com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.4.0"}
+                    :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}
+                                  com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}
                                   funcool/promesa                          {:mvn/version "2.0.1"}
-                                  manifold                                 {:mvn/version "0.1.8"}
+                                  manifold/manifold                        {:mvn/version "0.1.8"}
                                   com.h2database/h2                        {:mvn/version "1.4.199"}
-                                  seancorfield/next.jdbc                   {:mvn/version "1.0.4"}
+                                  seancorfield/next.jdbc                   {:mvn/version "1.2.659"}
                                   funcool/clojure.jdbc                     {:mvn/version "0.9.0"}
                                   org.clojure/java.jdbc                    {:mvn/version "0.7.9"}
-                                  criterium                                {:mvn/version "0.4.5"}}}
+                                  criterium/criterium                      {:mvn/version "0.4.6"}}}
            :runner {:extra-deps {com.cognitect/test-runner
                                  {:git/url "https://github.com/cognitect-labs/test-runner"
                                   :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}

--- a/project.clj
+++ b/project.clj
@@ -8,18 +8,18 @@
             :comments "same as Clojure"}
   :scm {:name "git"
         :url "https://github.com/metosin/porsas"}
-  :dependencies [[org.postgresql/postgresql "42.2.6"]
+  :dependencies [[org.postgresql/postgresql "42.3.1"]
                  [io.reactiverse/reactive-pg-client "0.11.4"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
-                   :dependencies [[org.clojure/clojure "1.10.1"]
-                                  [com.clojure-goes-fast/clj-async-profiler "0.4.0"]
+                   :dependencies [[org.clojure/clojure "1.10.3"]
+                                  [com.clojure-goes-fast/clj-async-profiler "0.5.1"]
                                   [funcool/promesa "2.0.1"]
                                   [manifold "0.1.8"]
                                   [com.h2database/h2 "1.4.199"]
-                                  [seancorfield/next.jdbc "1.0.4"]
+                                  [seancorfield/next.jdbc "1.2.659"]
                                   [funcool/clojure.jdbc "0.9.0"]
                                   [org.clojure/java.jdbc "0.7.9"]
-                                  [criterium "0.4.5"]]}
+                                  [criterium "0.4.6"]]}
              :perf {:jvm-opts ^:replace ["-server"
                                          "-Xmx4096m"
                                          "-Dclojure.compiler.direct-linking=true"]}}


### PR DESCRIPTION
A fix for #11 

Noticed some perf degradation after bumping the version of `next.jdbc`, could be some internal changes there:

1. [next.jdbc: porsas compiled](https://github.com/metosin/porsas/blob/b52322a9647b30419f79672c8f776daa6ad81e9e/test/porsas/core_test.clj#L91): from ~1200ns to ~1800ns
2. [next.jdbc](https://github.com/metosin/porsas/blob/b52322a9647b30419f79672c8f776daa6ad81e9e/test/porsas/core_test.clj#L96): from ~2400ns to ~3200ns
