### PR TITLE
Adding a caching layer

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
                     :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}
                                   com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}
                                   org.clojure/core.cache                   {:mvn/version "1.0.225"}
-                                  com.appsflyer/cloffeine                  {:mvn/version "1.0.0"}
+                                  com.github.ben-manes.caffeine/caffeine   {:mvn/version "3.0.5"}
                                   funcool/promesa                          {:mvn/version "2.0.1"}
                                   manifold/manifold                        {:mvn/version "0.1.8"}
                                   com.h2database/h2                        {:mvn/version "1.4.199"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths   ["src"]
  :deps    {org.postgresql/postgresql {:mvn/version "42.3.1"}
            org.clojure/core.cache    {:mvn/version "1.0.225"}
+           com.appsflyer/cloffeine   {:mvn/version "1.0.0"}
            io.vertx/vertx-pg-client  {:mvn/version "4.2.1"}}
  :aliases {:test   {:extra-paths ["test"]
                     :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths   ["src"]
  :deps    {org.postgresql/postgresql {:mvn/version "42.3.1"}
-           org.clojure/core.cache    {:mvn/version "1.0.225"}
-           com.appsflyer/cloffeine   {:mvn/version "1.0.0"}
            io.vertx/vertx-pg-client  {:mvn/version "4.2.1"}}
  :aliases {:test   {:extra-paths ["test"]
                     :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}
                                   com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}
+                                  org.clojure/core.cache                   {:mvn/version "1.0.225"}
+                                  com.appsflyer/cloffeine                  {:mvn/version "1.0.0"}
                                   funcool/promesa                          {:mvn/version "2.0.1"}
                                   manifold/manifold                        {:mvn/version "0.1.8"}
                                   com.h2database/h2                        {:mvn/version "1.4.199"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:paths   ["src"]
  :deps    {org.postgresql/postgresql {:mvn/version "42.3.1"}
+           org.clojure/core.cache    {:mvn/version "1.0.225"}
            io.vertx/vertx-pg-client  {:mvn/version "4.2.1"}}
  :aliases {:test   {:extra-paths ["test"]
                     :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                    :dependencies [[org.clojure/clojure "1.10.3"]
                                   [com.clojure-goes-fast/clj-async-profiler "0.5.1"]
                                   [org.clojure/core.cache "1.0.225"]
-                                  [com.appsflyer/cloffeine "1.0.0"]
+                                  [com.github.ben-manes.caffeine/caffeine "3.0.5"]
                                   [funcool/promesa "2.0.1"]
                                   [manifold "0.1.8"]
                                   [com.h2database/h2 "1.4.199"]

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,8 @@
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojure "1.10.3"]
                                   [com.clojure-goes-fast/clj-async-profiler "0.5.1"]
+                                  [org.clojure/core.cache "1.0.225"]
+                                  [com.appsflyer/cloffeine "1.0.0"]
                                   [funcool/promesa "2.0.1"]
                                   [manifold "0.1.8"]
                                   [com.h2database/h2 "1.4.199"]

--- a/src/porsas/async.clj
+++ b/src/porsas/async.clj
@@ -104,7 +104,7 @@
   | `:cache`      | Optional [[porsas.cache/Cache]] instance to hold the compiled rowmappers"
   ([] (context {}))
   ([{:keys [row cache]}]
-   (let [cache (or cache (cache/create-cache))
+   (let [cache (or cache (cache/create-caffeine-cache))
          ->row (fn [_sql ^RowSet rs]
                  (let [cols (col-map rs)]
                    (cond

--- a/src/porsas/async.clj
+++ b/src/porsas/async.clj
@@ -104,7 +104,7 @@
   | `:cache`      | Optional [[porsas.cache/Cache]] instance to hold the compiled rowmappers"
   ([] (context {}))
   ([{:keys [row cache]}]
-   (let [cache (or cache (cache/create-caffeine-cache))
+   (let [cache (or cache ((requiring-resolve 'porsas.cache.caffeine/create-cache)))
          ->row (fn [_sql ^RowSet rs]
                  (let [cols (col-map rs)]
                    (cond

--- a/src/porsas/cache.clj
+++ b/src/porsas/cache.clj
@@ -1,5 +1,6 @@
 (ns porsas.cache
-  (:require [clojure.core.cache.wrapped :as c]))
+  (:require [clojure.core.cache.wrapped :as c]
+            [cloffeine.cache :as cache]))
 
 (defprotocol Cache
   (lookup-or-set [this k value-fn] "Lookup a value in the cache based on `k` and if not found set its value based on `value-fn` and returns it.")
@@ -8,11 +9,20 @@
 (defprotocol Cached
   (cache [this]))
 
-(defrecord CoreCache [a]
-    Cache
-    (lookup-or-set [this k value-fn]
-      (c/lookup-or-miss (:a this) k value-fn))
-    (elements [this] (into {} @(:a this))))
+(defrecord CoreCache [c]
+  Cache
+  (lookup-or-set [this k value-fn]
+    (c/lookup-or-miss (:c this) k value-fn))
+  (elements [this] (into {} @(:c this))))
 
 (defn create-cache []
-  (->CoreCache (c/basic-cache-factory {})))
+  (->CoreCache (c/lru-cache-factory {})))
+
+(defrecord CaffeineCache [c]
+  Cache
+  (lookup-or-set [this k value-fn]
+    (cache/get (:c this) k value-fn))
+  (elements [this] (into {} (cache/as-map (:c this)))))
+
+(defn create-caffeine-cache []
+  (->CaffeineCache (cache/make-cache)))

--- a/src/porsas/cache.clj
+++ b/src/porsas/cache.clj
@@ -1,0 +1,13 @@
+(ns porsas.cache
+  (:require [clojure.core.cache.wrapped :as c]))
+
+(defprotocol Cache
+  (lookup-or-set [this k value-fn] "Lookup a value in the cache based on `k` and if not found set its value based on `value-fn` and returns it.")
+  (elements [this] "Returns the actual state of the cache."))
+
+
+(defrecord CoreCache [a]
+    Cache
+    (lookup-or-set [this k value-fn]
+      (c/lookup-or-miss (:a this) k value-fn))
+    (elements [this] (into {} @(:a this))))

--- a/src/porsas/cache.clj
+++ b/src/porsas/cache.clj
@@ -1,28 +1,9 @@
-(ns porsas.cache
-  (:require [clojure.core.cache.wrapped :as c]
-            [cloffeine.cache :as cache]))
+(ns porsas.cache)
 
 (defprotocol Cache
-  (lookup-or-set [this k value-fn] "Lookup a value in the cache based on `k` and if not found set its value based on `value-fn` and returns it.")
+  (lookup-or-set [this k value-fn] "Lookups a value in the cache based on `k` and if not found sets its value based on `value-fn` and returns it.")
   (elements [this] "Returns the actual state of the cache."))
 
 (defprotocol Cached
   (cache [this]))
 
-(defrecord CoreCache [c]
-  Cache
-  (lookup-or-set [this k value-fn]
-    (c/lookup-or-miss (:c this) k value-fn))
-  (elements [this] (into {} @(:c this))))
-
-(defn create-cache []
-  (->CoreCache (c/lru-cache-factory {})))
-
-(defrecord CaffeineCache [c]
-  Cache
-  (lookup-or-set [this k value-fn]
-    (cache/get (:c this) k value-fn))
-  (elements [this] (into {} (cache/as-map (:c this)))))
-
-(defn create-caffeine-cache []
-  (->CaffeineCache (cache/make-cache)))

--- a/src/porsas/cache.clj
+++ b/src/porsas/cache.clj
@@ -5,9 +5,14 @@
   (lookup-or-set [this k value-fn] "Lookup a value in the cache based on `k` and if not found set its value based on `value-fn` and returns it.")
   (elements [this] "Returns the actual state of the cache."))
 
+(defprotocol Cached
+  (cache [this]))
 
 (defrecord CoreCache [a]
     Cache
     (lookup-or-set [this k value-fn]
       (c/lookup-or-miss (:a this) k value-fn))
     (elements [this] (into {} @(:a this))))
+
+(defn create-cache []
+  (->CoreCache (c/basic-cache-factory {})))

--- a/src/porsas/cache/caffeine.clj
+++ b/src/porsas/cache/caffeine.clj
@@ -1,12 +1,20 @@
 (ns porsas.cache.caffeine
-  (:require [cloffeine.cache :as cache]
-            [porsas.cache :as pc]))
+  (:require [porsas.cache :as pc])
+  (:import [com.github.benmanes.caffeine.cache Caffeine Cache]
+           java.util.function.Function))
+
+(defn ->function ^Function [f]
+  (reify Function
+    (apply [_this t]
+      (f t))))
 
 (defrecord CaffeineCache [c]
   pc/Cache
   (lookup-or-set [this k value-fn]
-    (cache/get (:c this) k value-fn))
-  (elements [this] (into {} (cache/as-map (:c this)))))
+    (.get ^Cache (:c this) k (->function value-fn)))
+  (elements [this] (into {} (.asMap ^Cache (:c this)))))
 
 (defn create-cache []
-  (->CaffeineCache (cache/make-cache)))
+  (->CaffeineCache (-> (Caffeine/newBuilder)
+                       (.maximumSize 10000)
+                       (.build))))

--- a/src/porsas/cache/caffeine.clj
+++ b/src/porsas/cache/caffeine.clj
@@ -1,0 +1,12 @@
+(ns porsas.cache.caffeine
+  (:require [cloffeine.cache :as cache]
+            [porsas.cache :as pc]))
+
+(defrecord CaffeineCache [c]
+  pc/Cache
+  (lookup-or-set [this k value-fn]
+    (cache/get (:c this) k value-fn))
+  (elements [this] (into {} (cache/as-map (:c this)))))
+
+(defn create-cache []
+  (->CaffeineCache (cache/make-cache)))

--- a/src/porsas/cache/core.clj
+++ b/src/porsas/cache/core.clj
@@ -1,0 +1,12 @@
+(ns porsas.cache.core
+  (:require [clojure.core.cache.wrapped :as c]
+            [porsas.cache :as pc]))
+
+(defrecord CoreCache [c]
+  pc/Cache
+  (lookup-or-set [this k value-fn]
+    (c/lookup-or-miss (:c this) k value-fn))
+  (elements [this] (into {} @(:c this))))
+
+(defn create-cache []
+  (->CoreCache (c/lru-cache-factory {})))

--- a/src/porsas/core.clj
+++ b/src/porsas/core.clj
@@ -9,9 +9,6 @@
 (defprotocol GetValue
   (get-value [this i]))
 
-(defprotocol Cached
-  (cache [this]))
-
 ;;
 ;; Implementation
 ;;

--- a/src/porsas/jdbc.clj
+++ b/src/porsas/jdbc.clj
@@ -1,8 +1,9 @@
 (ns porsas.jdbc
-  (:require [porsas.core :as p])
+  (:require [porsas.cache :as cache]
+            [porsas.core :as p])
   (:import (java.sql Connection PreparedStatement ResultSet ResultSetMetaData)
            (javax.sql DataSource)
-           (java.util Iterator Map)
+           java.util.Iterator
            (clojure.lang PersistentVector)))
 
 ;;
@@ -118,42 +119,39 @@
   | --------------|-------------|
   | `:row`        | Optional function of `rs->value` or a [[RowCompiler]] to convert rows into values
   | `:key`        | Optional function of `rs-meta i->key` to create key for map-results
-  | `:cache`      | Optional [[java.util.Map]] instance to hold the compiled rowmappers"
+  | `:cache`      | Optional [[porsas.cache/Cache]] instance to hold the compiled rowmappers"
   ([] (context {}))
-  ([{:keys [row key cache] :or {key (unqualified-key)
-                                cache (java.util.HashMap.)}}]
-   (let [cache (or cache (reify Map (get [_ _]) (put [_ _ _]) (entrySet [_])))
-         ->row (fn [sql rs]
-                 (let [cols (col-map rs key)
-                       row (cond
-                             (satisfies? p/RowCompiler row) (p/compile-row row (map last cols))
-                             row row
-                             :else (p/rs->map-of-cols cols))]
-                   (.put ^Map cache sql row)
-                   row))]
+  ([{:keys [row key cache] :or {key (unqualified-key)}}]
+   (let [c (or cache (cache/create-cache))
+         ->row (fn [_sql rs]
+                 (let [cols (col-map rs key)]
+                   (cond
+                     (satisfies? p/RowCompiler row) (p/compile-row row (map last cols))
+                     row                            row
+                     :else                          (p/rs->map-of-cols cols))))]
      (reify
-       p/Cached
-       (cache [_] (into {} cache))
+       cache/Cached
+       (cache [_] (cache/elements cache))
        Context
        (-query-one [_ connection sqlvec]
-         (let [sql (-get-sql sqlvec)
+         (let [sql    (-get-sql sqlvec)
                params (-get-parameter-iterator sqlvec)
-               ps (.prepareStatement ^Connection connection sql)]
+               ps     (.prepareStatement ^Connection connection sql)]
            (try
              (prepare! ps params)
-             (let [rs (.executeQuery ps)
-                   row (or (.get ^Map cache sql) (->row sql rs))]
-               (if (.next rs) (row rs)))
+             (let [rs  (.executeQuery ps)
+                   row (cache/lookup-or-set c sql #(->row %1 rs))]
+               (when (.next rs) (row rs)))
              (finally
                (.close ps)))))
        (-query [_ connection sqlvec]
          (let [sql (-get-sql sqlvec)
-               it (-get-parameter-iterator sqlvec)
-               ps (.prepareStatement ^Connection connection sql)]
+               it  (-get-parameter-iterator sqlvec)
+               ps  (.prepareStatement ^Connection connection sql)]
            (try
              (prepare! ps it)
-             (let [rs (.executeQuery ps)
-                   row (or (.get ^Map cache sql) (->row sql rs))]
+             (let [rs  (.executeQuery ps)
+                   row (cache/lookup-or-set c sql #(->row %1 rs))]
                (loop [res []]
                  (if (.next rs)
                    (recur (conj res (row rs)))

--- a/src/porsas/jdbc.clj
+++ b/src/porsas/jdbc.clj
@@ -122,7 +122,7 @@
   | `:cache`      | Optional [[porsas.cache/Cache]] instance to hold the compiled rowmappers"
   ([] (context {}))
   ([{:keys [row key cache] :or {key (unqualified-key)}}]
-   (let [c (or cache (cache/create-cache))
+   (let [c (or cache (cache/create-caffeine-cache))
          ->row (fn [_sql rs]
                  (let [cols (col-map rs key)]
                    (cond

--- a/src/porsas/jdbc.clj
+++ b/src/porsas/jdbc.clj
@@ -122,7 +122,7 @@
   | `:cache`      | Optional [[porsas.cache/Cache]] instance to hold the compiled rowmappers"
   ([] (context {}))
   ([{:keys [row key cache] :or {key (unqualified-key)}}]
-   (let [c (or cache (cache/create-caffeine-cache))
+   (let [c (or cache ((requiring-resolve 'porsas.cache.caffeine/create-cache)))
          ->row (fn [_sql rs]
                  (let [cols (col-map rs key)]
                    (cond

--- a/src/porsas/next.clj
+++ b/src/porsas/next.clj
@@ -12,7 +12,7 @@
   ([key & {:keys [cache]}]
    (let [cache (or cache ((requiring-resolve 'porsas.cache.caffeine/create-cache)))]
      (fn [^ResultSet rs opts]
-       (let [sql   (:next.jdbc/sql-string opts)
+       (let [sql   (:next.jdbc/sql-params opts)
              ->row (cache/lookup-or-set cache sql (fn [_] (p/rs-> 1 nil (map last (pj/col-map rs key)))))]
          (reify
            cache/Cached

--- a/src/porsas/next.clj
+++ b/src/porsas/next.clj
@@ -9,8 +9,8 @@
   "A [[next.jdbc.result-set/RowBuilder]] implementation using porsas. WIP."
   ([]
    (caching-row-builder (pj/qualified-key)))
-  ([key]
-   (let [cache (cache/create-caffeine-cache)]
+  ([key & {:keys [cache]}]
+   (let [cache (or cache ((requiring-resolve 'porsas.cache.caffeine/create-cache)))]
      (fn [^ResultSet rs opts]
        (let [sql   (:next.jdbc/sql-string opts)
              ->row (cache/lookup-or-set cache sql (fn [_] (p/rs-> 1 nil (map last (pj/col-map rs key)))))]

--- a/src/porsas/next.clj
+++ b/src/porsas/next.clj
@@ -10,7 +10,7 @@
   ([]
    (caching-row-builder (pj/qualified-key)))
   ([key]
-   (let [cache (cache/create-cache)]
+   (let [cache (cache/create-caffeine-cache)]
      (fn [^ResultSet rs opts]
        (let [sql   (:next.jdbc/sql-string opts)
              ->row (cache/lookup-or-set cache sql (fn [_] (p/rs-> 1 nil (map last (pj/col-map rs key)))))]

--- a/test/porsas/async_test.clj
+++ b/test/porsas/async_test.clj
@@ -6,9 +6,8 @@
    [manifold.deferred :as d])
   (:import io.vertx.pgclient.PgPool))
 
-(def pool-opts {:uri      "postgresql://localhost:5432/porsas"
-                :user     "user"
-                :password "password"})
+(def pool-opts {:uri  "postgresql://localhost:5432/porsas"
+                :user "postgres"})
 
 (t/deftest async
   (let [pool (pa/pool pool-opts)]
@@ -17,7 +16,7 @@
                  (pa/then :name)
                  (deref))))
 
-    (t/is (= "io.reactiverse.pgclient.PgException: relation \"non_existing\" does not exist"
+    (t/is (= "io.vertx.pgclient.PgException: ERROR: relation \"non_existing\" does not exist (42P01)"
              (-> (pa/query-one pool ["SELECT * from non_existing where id=$1" 1])
                  (pa/then :name)
                  (pa/catch #(-> % .getMessage))

--- a/test/porsas/cache_test.clj
+++ b/test/porsas/cache_test.clj
@@ -1,13 +1,20 @@
 (ns porsas.cache-test
   (:require [clojure.test :as t]
-            [clojure.core.cache.wrapped :as c]
-            [porsas.cache :as sut]))
+            [clojure.template :refer [do-template]]
+            [porsas.cache :as sut]
+            [porsas.cache.core :as core]
+            [porsas.cache.caffeine :as caffeine]))
 
 (t/deftest cache
-  (let [c (sut/->CoreCache (c/basic-cache-factory {}))]
-    (t/is (= {} (sut/elements c)))
+  (do-template
+    [t cache]
+    (let [c cache]
+      (t/testing t
+        (t/is (= {} (sut/elements c)))
 
-    (t/is (= ::a (sut/lookup-or-set c :a (constantly ::a))))
-    (t/is (= ::a (sut/lookup-or-set c :a (constantly ::b))))
+        (t/is (= ::a (sut/lookup-or-set c :a (constantly ::a))))
+        (t/is (= ::a (sut/lookup-or-set c :a (constantly ::b))))
 
-    (t/is (= {:a ::a} (sut/elements c)))))
+        (t/is (= {:a ::a} (sut/elements c)))))
+    "core cache" (core/create-cache)
+    "caffeine" (caffeine/create-cache)))

--- a/test/porsas/cache_test.clj
+++ b/test/porsas/cache_test.clj
@@ -1,0 +1,13 @@
+(ns porsas.cache-test
+  (:require [clojure.test :as t]
+            [clojure.core.cache.wrapped :as c]
+            [porsas.cache :as sut]))
+
+(t/deftest cache
+  (let [c (sut/->CoreCache (c/basic-cache-factory {}))]
+    (t/is (= {} (sut/elements c)))
+
+    (t/is (= ::a (sut/lookup-or-set c :a (constantly ::a))))
+    (t/is (= ::a (sut/lookup-or-set c :a (constantly ::b))))
+
+    (t/is (= {:a ::a} (sut/elements c)))))


### PR DESCRIPTION
Fixes #7 

I've added a default implementation for the `Cache` protocol which uses `core.cache`.  Users could implement their own using a different caching lib and pass it in.

Ran the load tests, this implementation added ~200ns to the original measurements using `basic-cache` which is basically a fancy map, using `lru-cache` and `lu-cache` are doubled the measured times. The existing perf-test won't really show the advantages of the more advanced caches as it uses only one query so the eviction is not kicking in. By default, `basic-cache` is created for now, although that's not bounded so I guess the memory leak problem could still exist.

Added `caffeine` based solution too, with the default cache settings it seems much faster than the `core.cache`-based impl.