### PR TITLE
Bump deps to fix CVEs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths   ["src"]
- :deps    {org.postgresql/postgresql {:mvn/version "42.3.1"}
-           io.vertx/vertx-pg-client  {:mvn/version "4.2.1"}}
+ :deps    {org.postgresql/postgresql {:mvn/version "42.3.3"}
+           io.vertx/vertx-pg-client  {:mvn/version "4.2.5"}}
  :aliases {:test   {:extra-paths ["test"]
                     :extra-deps  {org.clojure/clojure                      {:mvn/version "1.10.3"}
                                   com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -15,4 +15,11 @@
                                  {:git/url "https://github.com/cognitect-labs/test-runner"
                                   :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
                     :main-opts  ["-m" "cognitect.test-runner"
-                                 "-d" "test"]}}}
+                                 "-d" "test"]}
+
+           :nvd    {; clojure -X:nvd :classpath '"'"$(lein with-profile -base,-system,-user,-provided,-dev classpath)"'"' 2>/dev/null && clojure -X:nvd :classpath '"'"$(clojure -Srepro -Spath)"'"' 2>/dev/null
+                    :replace-paths []
+                    :replace-deps  {nvd-clojure/nvd-clojure {:mvn/version "RELEASE"}}
+                    :exec-fn       nvd.task/check
+                    :exec-args     {:config-filename "nvd-clojure.json"}
+                    :jvm-opts      ["-Dclojure.main.report=stderr"]}}}

--- a/nvd-clojure.json
+++ b/nvd-clojure.json
@@ -1,0 +1,1 @@
+{"nvd": {"suppression-file": "nvd_suppressions.xml"}}

--- a/nvd_suppressions.xml
+++ b/nvd_suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: vertx-pg-client-4.*.jar
+
+   These CVEs affect postgres servers, not clients like the current project.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.vertx/vertx\-pg\-client@4\..*$</packageUrl>
+        <cpe>cpe:/a:postgresql:postgresql</cpe>
+    </suppress>
+</suppressions>

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
             :comments "same as Clojure"}
   :scm {:name "git"
         :url "https://github.com/metosin/porsas"}
-  :dependencies [[org.postgresql/postgresql "42.3.1"]
-                 [io.vertx/vertx-pg-client  "4.2.1"]]
+  :dependencies [[org.postgresql/postgresql "42.3.3"]
+                 [io.vertx/vertx-pg-client  "4.2.5"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojure "1.10.3"]
                                   [com.clojure-goes-fast/clj-async-profiler "0.5.1"]


### PR DESCRIPTION
Fixes #18 

```shell
clojure -X:nvd :classpath '"'"$(lein with-profile -base,-system,-user,-provided,-dev classpath)"'"' 2>/dev/null && clojure -X:nvd :classpath '"'"$(clojure -Srepro -Spath)"'"' 2>/dev/null
```

```
Checking dependencies for stdin  ...
  using nvd-clojure:  and dependency-check: 6.5.3

0 vulnerabilities detected. Severity: NONE
Detailed reports saved in: /Users/ikoszo/opensource/porsas/target/nvd

   *** THIS REPORT IS WITHOUT WARRANTY ***
Checking dependencies for stdin  ...
  using nvd-clojure:  and dependency-check: 6.5.3

0 vulnerabilities detected. Severity: NONE
Detailed reports saved in: /Users/ikoszo/opensource/porsas/target/nvd

   *** THIS REPORT IS WITHOUT WARRANTY ***
```